### PR TITLE
Performance improvements

### DIFF
--- a/src/basic_potentials.jl
+++ b/src/basic_potentials.jl
@@ -115,7 +115,7 @@ function pairwise_electrostatic_acceleration!(dv,
     n::Integer,
     qs::Vector{<:Real},
     ms::Vector{<:Real},
-    exclude::Dict{Int, Set{Int}},
+    exclude::Dict{Int, Vector{Int}},
     p::ElectrostaticParameters,
     pbc::BoundaryConditions)
 

--- a/src/basic_potentials.jl
+++ b/src/basic_potentials.jl
@@ -115,7 +115,7 @@ function pairwise_electrostatic_acceleration!(dv,
     n::Integer,
     qs::Vector{<:Real},
     ms::Vector{<:Real},
-    exclude::Dict{Int, Vector{Int}},
+    exclude::Dict{Int, Set{Int}},
     p::ElectrostaticParameters,
     pbc::BoundaryConditions)
 

--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -33,7 +33,6 @@ end
 
 function get_interparticle_distance(ri, rj, pbc::PeriodicBoundaryConditions)
     rij = ri - rj
-    r, r2 = zero(eltype(ri)), zero(eltype(ri))
     x, y, z = rij
     while x  < pbc[1]   x += pbc[2]-pbc[1] end
     while x >= pbc[2]   x -= pbc[2]-pbc[1] end
@@ -42,7 +41,7 @@ function get_interparticle_distance(ri, rj, pbc::PeriodicBoundaryConditions)
     while z  < pbc[5]   z += pbc[6]-pbc[5] end
     while z >= pbc[6]   z -= pbc[6]-pbc[5] end
     rij = @SVector [x, y, z]
-    r2 = dot(rij, rij)
+    r2 = rij[1]^2 + rij[2]^2 + rij[3]^2
     r = sqrt(r2)
     return (rij, r, r2)
 end
@@ -59,14 +58,14 @@ function get_interparticle_distance(ri, rj, bc::CubicPeriodicBoundaryConditions)
     while z >= radius    z -= size end
     while z < -radius    z += size end
     rij = @SVector [x, y, z]
-    r2 = dot(rij, rij)
+    r2 = rij[1]^2 + rij[2]^2 + rij[3]^2
     r = sqrt(r2)
     return (rij, r, r2)
 end
 
 function get_interparticle_distance(ri, rj, ::BoundaryConditions)
     rij = ri - rj
-    r2 = dot(rij, rij)
+    r2 = rij[1]^2 + rij[2]^2 + rij[3]^2
     r = sqrt(r2)
     (rij, r, r2)
 end

--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -51,21 +51,17 @@ function apply_boundary_conditions!(ri, rj, pbc::PeriodicBoundaryConditions, R2)
 end
 
 function apply_boundary_conditions!(ri, rj, pbc::CubicPeriodicBoundaryConditions, R2)
-    rij = SVector{3,typeof(R2)}(Inf, Inf, Inf)
-    success = false
-    rij2 = zero(typeof(R2))
-    shifts = SVector{3,typeof(R2)}(0, -pbc.L, pbc.L)
-    for dx ∈ shifts, dy ∈ shifts, dz ∈ shifts
-        dr = SVector{3,typeof(R2)}(dx, dy, dz)
-        rij = ri - rj + dr
-        rij = rij - pbc.L * sign.(rij) .* sign(pbc.L) .* floor.(abs.(rij) / abs(pbc.L))
-        rij2 = dot(rij, rij)
-        if rij2 < R2
-            success = true
-            break
-        end
-    end
-    return (rij, rij2, success)
+    rij = ri - rj
+    x, y, z = rij[1], rij[2], rij[3]
+    while x >= pbc.L    x -= pbc.L end
+    while x < -pbc.L    x += pbc.L end
+    while y >= pbc.L    y -= pbc.L end
+    while y < -pbc.L    y += pbc.L end
+    while z >= pbc.L    z -= pbc.L end
+    while z < -pbc.L    z += pbc.L end
+    rij = SVector{3,eltype(R2)}(x, y, z)
+    rij2 = dot(rij, rij)
+    return (rij, rij2, rij2 < R2)
 end
 
 function apply_boundary_conditions!(ri, rj, pbc::BoundaryConditions, R2)

--- a/src/nbody_simulation_result.jl
+++ b/src/nbody_simulation_result.jl
@@ -198,7 +198,7 @@ function lennard_jones_potential(p::LennardJonesParameters, indxs::Vector{<:Inte
     return 4 * p.ϵ * e_lj
 end
 
-function electrostatic_potential(p::ElectrostaticParameters, indxs::Vector{<:Integer}, exclude::Dict{Int,Vector{Int}}, qs, rs, pbc::BoundaryConditions)
+function electrostatic_potential(p::ElectrostaticParameters, indxs::Vector{<:Integer}, exclude::Dict{Int,Set{Int}}, qs, rs, pbc::BoundaryConditions)
     e_el = 0.0
 
     n = length(indxs)

--- a/src/nbody_simulation_result.jl
+++ b/src/nbody_simulation_result.jl
@@ -32,7 +32,7 @@ end
 
 function get_velocity(sr::SimulationResult, time::Real, i::Integer=0)
     n = get_coordinate_vector_count(sr.simulation.system)
-    
+
     if typeof(sr.solution[1]) <: RecursiveArrayTools.ArrayPartition
         velocities = sr(time).x[1]
         if i <= 0
@@ -183,13 +183,13 @@ function lennard_jones_potential(p::LennardJonesParameters, indxs::Vector{<:Inte
             j = indxs[ind_j]
             rj = @SVector [coordinates[1, j], coordinates[2, j], coordinates[3, j]]
 
-            (rij, rij_2, success) = apply_boundary_conditions!(ri, rj, pbc, p.R2)
+            (rij, r, r2) = get_interparticle_distance(ri, rj, pbc)
 
-            if !success
-                rij_2 = p.R2
+            if !(r2 < p.R2)
+                r2 = p.R2
             end
 
-            σ_rij_6 = (p.σ2 / rij_2)^3
+            σ_rij_6 = (p.σ2 / r2)^3
             σ_rij_12 = σ_rij_6^2
             e_lj += (σ_rij_12 - σ_rij_6 )
         end
@@ -211,9 +211,9 @@ function electrostatic_potential(p::ElectrostaticParameters, indxs::Vector{<:Int
             if !in(j, exclude[i])
                 rj = @SVector [rs[1, j], rs[2, j], rs[3, j]]
 
-                (rij, rij_2, success) = apply_boundary_conditions!(ri, rj, pbc, p.R2)
-                if !success
-                    rij = p.R
+                (rij, r, r2) = get_interparticle_distance(ri, rj, pbc)
+                if !(r2 < p.R2)
+                    rij = p.R # NOTE: hmm?
                 end
 
                 e_el_i += qs[j] / norm(rij)
@@ -461,11 +461,10 @@ function rdf(sr::SimulationResult)
                 j = indxs[ind_j]
                 rj = @SVector [cc[1, j], cc[2, j], cc[3, j]]
 
-                (rij, rij_2, success) = apply_boundary_conditions!(ri, rj, pbc, (0.5 * pbc.L)^2)
+                (rij, r, r2) = get_interparticle_distance(ri, rj, pbc)
 
-                if success
-                    rij_1 = sqrt(rij_2)
-                    bin = ceil(Int, rij_1 / dr)
+                if r2 < (0.5 * pbc.L)^2
+                    bin = ceil(Int, r / dr)
                     if bin > 1 && bin <= maxbin
                         hist[bin] += 2
                     end
@@ -567,12 +566,12 @@ function write_pdb_data(f::IO, sr::SimulationResult{<:WaterSPCFw})
             @. cc[:, indH2] = cc[:,indO] + cc0[:, indH2] - cc0[:, indO]
         end
 
-        count+=1      
+        count+=1
         println(f,rpad("MODEL",10), count)
         println(f,"REMARK 250 time=$t picoseconds")
         for i ∈ 1:n
             indO, indH1, indH2 = 3 * (i - 1) + 1, 3 * (i - 1) + 2, 3 * (i - 1) + 3
-            
+
             println(f,"HETATM",lpad(indO,5),"  ",rpad("O",4),"HOH",lpad(i,6),"    ", lpad(@sprintf("%8.3f",cc[1,indO]),8), lpad(@sprintf("%8.3f",cc[2,indO]),8), lpad(@sprintf("%8.3f",cc[3,indO]),8),lpad("1.00",6),lpad("0.00",6), lpad("",10), lpad("O",2))
             println(f,"HETATM",lpad(indH1,5),"  ",rpad("H1",4),"HOH",lpad(i,6),"    ", lpad(@sprintf("%8.3f",cc[1,indH1]),8), lpad(@sprintf("%8.3f",cc[2,indH1]),8), lpad(@sprintf("%8.3f",cc[3,indH1]),8),lpad("1.00",6),lpad("0.00",6), lpad("",10), lpad("H",2))
             println(f,"HETATM",lpad(indH2,5),"  ",rpad("H2",4),"HOH",lpad(i,6),"    ", lpad(@sprintf("%8.3f",cc[1,indH2]),8), lpad(@sprintf("%8.3f",cc[2,indH2]),8), lpad(@sprintf("%8.3f",cc[3,indH2]),8),lpad("1.00",6),lpad("0.00",6), lpad("",10), lpad("H",2))
@@ -588,11 +587,11 @@ function write_pdb_data(f::IO, sr::SimulationResult)
     for t in sr.solution.t
         cc = 10*get_position(sr, t)
         map!(x ->  x -= L * floor(x / L), cc, cc)
-        count+=1      
+        count+=1
         println(f,rpad("MODEL",10), count)
         println(f,"REMARK 250 time=$t steps")
         for i ∈ 1:n
-            
+
             println(f,"HETATM",lpad(i,5),"  ",rpad("Ar",4),"Ar",lpad(i,6),"    ", lpad(@sprintf("%8.3f",cc[1,i]),8), lpad(@sprintf("%8.3f",cc[2,i]),8), lpad(@sprintf("%8.3f",cc[3,i]),8),lpad("1.00",6),lpad("0.00",6), lpad("",10), lpad("Ar",2))
         end
         println(f,"ENDMDL")
@@ -656,7 +655,7 @@ function extract_from_pdb(file)
             break
         end
     end
-    
+
 
     ln_time = readline(file)
     parts = split(ln_time)
@@ -687,7 +686,7 @@ function extract_from_pdb(file)
 
             push!(wms, WaterMolecule(o,h1,h2))
         end
-    end       
+    end
 
     wms
 end

--- a/src/nbody_simulation_result.jl
+++ b/src/nbody_simulation_result.jl
@@ -198,7 +198,7 @@ function lennard_jones_potential(p::LennardJonesParameters, indxs::Vector{<:Inte
     return 4 * p.ϵ * e_lj
 end
 
-function electrostatic_potential(p::ElectrostaticParameters, indxs::Vector{<:Integer}, exclude::Dict{Int,Set{Int}}, qs, rs, pbc::BoundaryConditions)
+function electrostatic_potential(p::ElectrostaticParameters, indxs::Vector{<:Integer}, exclude::Dict{Int,Vector{Int}}, qs, rs, pbc::BoundaryConditions)
     e_el = 0.0
 
     n = length(indxs)

--- a/src/nbody_simulation_result.jl
+++ b/src/nbody_simulation_result.jl
@@ -199,24 +199,25 @@ function lennard_jones_potential(p::LennardJonesParameters, indxs::Vector{<:Inte
 end
 
 function electrostatic_potential(p::ElectrostaticParameters, indxs::Vector{<:Integer}, exclude::Dict{Int,Vector{Int}}, qs, rs, pbc::BoundaryConditions)
-    e_el = 0
+    e_el = 0.0
 
     n = length(indxs)
     for ind_i = 1:n
         i = indxs[ind_i]
         ri = @SVector [rs[1, i], rs[2, i], rs[3, i]]
-        e_el_i = 0
+        e_el_i = 0.0
         for ind_j = ind_i + 1:n
             j = indxs[ind_j]
             if !in(j, exclude[i])
                 rj = @SVector [rs[1, j], rs[2, j], rs[3, j]]
 
                 (rij, r, r2) = get_interparticle_distance(ri, rj, pbc)
-                if !(r2 < p.R2)
-                    rij = p.R # NOTE: hmm?
-                end
 
-                e_el_i += qs[j] / norm(rij)
+                if r2 < p.R2
+                    e_el_i += qs[j] / r
+                else
+                    e_el_i += qs[j] / p.R
+                end
             end
         end
         e_el += e_el_i * qs[i]

--- a/src/nbody_to_ode.jl
+++ b/src/nbody_to_ode.jl
@@ -179,11 +179,11 @@ function obtain_data_for_electrostatic_interaction(system::PotentialNBodySystem)
     qs = zeros(typeof(first(bodies).q), n)
     ms = zeros(typeof(first(bodies).m), n)
     indxs = collect(1:n)
-    exclude = Dict{Int, Set{Int}}()
+    exclude = Dict{Int, Vector{Int}}()
     for i = 1:n
         qs[i] = bodies[i].q
         ms[i] = bodies[i].m
-        exclude[i] = Set{Int}(i)
+        exclude[i] = [i]
     end
     return (qs, ms, indxs, exclude)
 end
@@ -194,7 +194,7 @@ function obtain_data_for_electrostatic_interaction(system::WaterSPCFw)
     qs = zeros(3 * n)
     ms = zeros(3 * n)
     indxs = collect(1:3*n)
-    exclude = Dict{Int, Set{Int}}()
+    exclude = Dict{Int, Vector{Int}}()
     for i = 1:n
         Oind = 3 * (i - 1) + 1
         qs[Oind] = system.qO
@@ -203,9 +203,9 @@ function obtain_data_for_electrostatic_interaction(system::WaterSPCFw)
         ms[Oind] = system.mO
         ms[Oind + 1] = system.mH
         ms[Oind + 2] = system.mH
-        exclude[Oind] = Set{Int}((Oind, Oind+1, Oind+2,3*n+1))
-        exclude[Oind+1] = Set{Int}((Oind, Oind+1, Oind+2,3*n+1))
-        exclude[Oind+2] = Set{Int}((Oind, Oind+1, Oind+2,3*n+1))
+        exclude[Oind] = [Oind, Oind+1, Oind+2,3*n+1]
+        exclude[Oind+1] = [Oind, Oind+1, Oind+2,3*n+1]
+        exclude[Oind+2] = [Oind, Oind+1, Oind+2,3*n+1]
     end
     return (qs, ms, indxs, exclude)
 end

--- a/src/nbody_to_ode.jl
+++ b/src/nbody_to_ode.jl
@@ -179,11 +179,11 @@ function obtain_data_for_electrostatic_interaction(system::PotentialNBodySystem)
     qs = zeros(typeof(first(bodies).q), n)
     ms = zeros(typeof(first(bodies).m), n)
     indxs = collect(1:n)
-    exclude = Dict{Int, Vector{Int}}()
+    exclude = Dict{Int, Set{Int}}()
     for i = 1:n
         qs[i] = bodies[i].q
         ms[i] = bodies[i].m
-        exclude[i] = [i]
+        exclude[i] = Set{Int}(i)
     end
     return (qs, ms, indxs, exclude)
 end
@@ -194,7 +194,7 @@ function obtain_data_for_electrostatic_interaction(system::WaterSPCFw)
     qs = zeros(3 * n)
     ms = zeros(3 * n)
     indxs = collect(1:3*n)
-    exclude = Dict{Int, Vector{Int}}()
+    exclude = Dict{Int, Set{Int}}()
     for i = 1:n
         Oind = 3 * (i - 1) + 1
         qs[Oind] = system.qO
@@ -203,9 +203,9 @@ function obtain_data_for_electrostatic_interaction(system::WaterSPCFw)
         ms[Oind] = system.mO
         ms[Oind + 1] = system.mH
         ms[Oind + 2] = system.mH
-        exclude[Oind] = [Oind, Oind+1, Oind+2,3*n+1]
-        exclude[Oind+1] = [Oind, Oind+1, Oind+2,3*n+1]
-        exclude[Oind+2] = [Oind, Oind+1, Oind+2,3*n+1]
+        exclude[Oind] = Set{Int}((Oind, Oind+1, Oind+2,3*n+1))
+        exclude[Oind+1] = Set{Int}((Oind, Oind+1, Oind+2,3*n+1))
+        exclude[Oind+2] = Set{Int}((Oind, Oind+1, Oind+2,3*n+1))
     end
     return (qs, ms, indxs, exclude)
 end

--- a/src/nbody_to_ode.jl
+++ b/src/nbody_to_ode.jl
@@ -124,7 +124,7 @@ end
 function obtain_data_for_harmonic_bond_interaction(system::WaterSPCFw, p::SPCFwParameters)
     neighbouhoods = Dict{Int, Vector{Tuple{Int,Float64}}}()
     n = length(system.bodies)
-    ms = zeros(typeof(first(system.bodies).m), 3 * n)
+    ms = zeros(3 * n)
     for i in 1:n
         indO, indH1, indH2 = 3 * (i - 1) + 1, 3 * (i - 1) + 2, 3 * (i - 1) + 3
         ms[indO] = system.mO
@@ -162,7 +162,7 @@ end
 function obtain_data_for_lennard_jones_interaction(system::WaterSPCFw)
     bodies = system.bodies
     n = length(bodies)
-    ms = zeros(typeof(first(bodies).m), 3 * n)
+    ms = zeros(3 * n)
     indxs = zeros(Int, n)
     for i = 1:n
         indxs[i] = 3 * (i - 1) + 1
@@ -191,8 +191,8 @@ end
 function obtain_data_for_electrostatic_interaction(system::WaterSPCFw)
     bodies = system.bodies
     n = length(bodies)
-    qs = zeros(typeof(first(bodies).m), 3 * n)
-    ms = zeros(typeof(first(bodies).m), 3 * n)
+    qs = zeros(3 * n)
+    ms = zeros(3 * n)
     indxs = collect(1:3*n)
     exclude = Dict{Int, Vector{Int}}()
     for i = 1:n
@@ -222,7 +222,7 @@ function obtain_data_for_valence_angle_harmonic_interaction(system::WaterSPCFw)
     p = system.scpfw_parameters
     bonds = Vector{Tuple{Int, Int, Int, Float64, Float64}}()
     n = length(system.bodies)
-    ms = zeros(typeof(first(bodies).m), 3 * n)
+    ms = zeros(3 * n)
     for i = 1:n
         indO, indH1, indH2 = 3 * (i - 1) + 1, 3 * (i - 1) + 2, 3 * (i - 1) + 3
         ms[indO] = system.mO

--- a/src/nbody_to_ode.jl
+++ b/src/nbody_to_ode.jl
@@ -2,7 +2,7 @@ function gather_bodies_initial_coordinates(simulation::NBodySimulation)
     system = simulation.system
     bodies = system.bodies;
     len = n = length(bodies)
-    
+
     if simulation.thermostat isa NoseHooverThermostat
         len +=1
     end
@@ -11,9 +11,9 @@ function gather_bodies_initial_coordinates(simulation::NBodySimulation)
     v0 = zeros(3, len)
 
     for i = 1:n
-        u0[:, i] = bodies[i].r 
+        u0[:, i] = bodies[i].r
         v0[:, i] = bodies[i].v
-    end 
+    end
 
     (u0, v0, n)
 end
@@ -23,7 +23,7 @@ function gather_bodies_initial_coordinates(simulation::NBodySimulation{<:WaterSP
     molecules = system.bodies;
     n = length(molecules)
     len = 3*n
-    
+
     if simulation.thermostat isa NoseHooverThermostat
         len = 3*n+1
     end
@@ -42,13 +42,13 @@ function gather_atom_coordinates(system::WaterSPCFw{<:MassBody}, len)
     for i = 1:n
         p = system.scpfw_parameters
         indO, indH1, indH2 = 3 * (i - 1) + 1, 3 * (i - 1) + 2, 3 * (i - 1) + 3
-        u0[:, indO] = molecules[i].r 
+        u0[:, indO] = molecules[i].r
         u0[:, indH1] = molecules[i].r .+ [p.rOH, 0.0, 0.0]
         u0[:, indH2] = molecules[i].r .+ [cos(p.aHOH) * p.rOH, 0.0, sin(p.aHOH) * p.rOH]
         v0[:, indO] = molecules[i].v
         v0[:, indH1] = molecules[i].v
         v0[:, indH2] = molecules[i].v
-    end 
+    end
     (u0, v0)
 end
 
@@ -61,7 +61,7 @@ function gather_atom_coordinates(system::WaterSPCFw{<:WaterMolecule}, len)
     for i = 1:n
         p = system.scpfw_parameters
         indO, indH1, indH2 = 3 * (i - 1) + 1, 3 * (i - 1) + 2, 3 * (i - 1) + 3
-        u0[:, indO] = molecules[i].O.r 
+        u0[:, indO] = molecules[i].O.r
         u0[:, indH1]  = molecules[i].H1.r
         u0[:, indH2] = molecules[i].H2.r
         v0[:, indO] = molecules[i].O.v
@@ -79,7 +79,7 @@ end
 
 function gather_accelerations_for_potentials(simulation::NBodySimulation{<:PotentialNBodySystem})
     acceleration_functions = []
-    
+
     for (potential, parameters) in simulation.system.potentials
         push!(acceleration_functions, get_accelerating_function(parameters, simulation))
     end
@@ -90,7 +90,7 @@ end
 function gather_group_accelerations(simulation::NBodySimulation{<:WaterSPCFw})
     acelerations = []
     push!(acelerations, get_group_accelerating_function(simulation.system.scpfw_parameters, simulation))
-    acelerations    
+    acelerations
 end
 
 function get_accelerating_function(parameters::LennardJonesParameters, simulation::NBodySimulation)
@@ -124,7 +124,7 @@ end
 function obtain_data_for_harmonic_bond_interaction(system::WaterSPCFw, p::SPCFwParameters)
     neighbouhoods = Dict{Int, Vector{Tuple{Int,Float64}}}()
     n = length(system.bodies)
-    ms = zeros(3 * n)
+    ms = zeros(typeof(first(system.bodies).m), 3 * n)
     for i in 1:n
         indO, indH1, indH2 = 3 * (i - 1) + 1, 3 * (i - 1) + 2, 3 * (i - 1) + 3
         ms[indO] = system.mO
@@ -143,56 +143,56 @@ function obtain_data_for_harmonic_bond_interaction(system::WaterSPCFw, p::SPCFwP
         neighbouhoods[indH1] = neighbours_h1
         neighbouhoods[indH2] = neighbours_h2
     end
-    
+
     (ms, neighbouhoods)
 end
 
 function obtain_data_for_lennard_jones_interaction(system::PotentialNBodySystem)
     bodies = system.bodies
     n = length(bodies)
-    ms = zeros(Real, n)
-    indxs = zeros(Integer, n)
+    ms = zeros(typeof(first(bodies).m), n)
+    indxs = zeros(Int, n)
     for i = 1:n
         ms[i] = bodies[i].m
         indxs[i] = i
-    end 
+    end
     return (ms, indxs)
 end
 
 function obtain_data_for_lennard_jones_interaction(system::WaterSPCFw)
     bodies = system.bodies
     n = length(bodies)
-    ms = zeros(Real, 3 * n)
-    indxs = zeros(Integer, n)
+    ms = zeros(typeof(first(bodies).m), 3 * n)
+    indxs = zeros(Int, n)
     for i = 1:n
         indxs[i] = 3 * (i - 1) + 1
         ms[3 * (i - 1) + 1] = system.mO
         ms[3 * (i - 1) + 2] = system.mH
         ms[3 * (i - 1) + 3] = system.mH
-    end 
+    end
     return (ms, indxs)
 end
 
 function obtain_data_for_electrostatic_interaction(system::PotentialNBodySystem)
     bodies = system.bodies
     n = length(bodies)
-    qs = zeros(Real, n)
-    ms = zeros(Real, n)
+    qs = zeros(typeof(first(bodies).q), n)
+    ms = zeros(typeof(first(bodies).m), n)
     indxs = collect(1:n)
     exclude = Dict{Int, Vector{Int}}()
     for i = 1:n
         qs[i] = bodies[i].q
         ms[i] = bodies[i].m
         exclude[i] = [i]
-    end 
+    end
     return (qs, ms, indxs, exclude)
 end
 
 function obtain_data_for_electrostatic_interaction(system::WaterSPCFw)
     bodies = system.bodies
     n = length(bodies)
-    qs = zeros(Real, 3 * n)
-    ms = zeros(Real, 3 * n)
+    qs = zeros(typeof(first(bodies).m), 3 * n)
+    ms = zeros(typeof(first(bodies).m), 3 * n)
     indxs = collect(1:3*n)
     exclude = Dict{Int, Vector{Int}}()
     for i = 1:n
@@ -206,15 +206,15 @@ function obtain_data_for_electrostatic_interaction(system::WaterSPCFw)
         exclude[Oind] = [Oind, Oind+1, Oind+2,3*n+1]
         exclude[Oind+1] = [Oind, Oind+1, Oind+2,3*n+1]
         exclude[Oind+2] = [Oind, Oind+1, Oind+2,3*n+1]
-    end 
+    end
     return (qs, ms, indxs, exclude)
 end
 
 function obtain_data_for_electrostatic_interaction(system::NBodySystem)
     bodies = system.bodies
     n = length(bodies)
-    qs = zeros(Real, n)
-    ms = zeros(Real, n)
+    qs = zeros(typeof(first(bodies).m), n)
+    ms = zeros(typeof(first(bodies).m), n)
     return (qs, ms)
 end
 
@@ -222,14 +222,14 @@ function obtain_data_for_valence_angle_harmonic_interaction(system::WaterSPCFw)
     p = system.scpfw_parameters
     bonds = Vector{Tuple{Int, Int, Int, Float64, Float64}}()
     n = length(system.bodies)
-    ms = zeros(Real, 3 * n)
+    ms = zeros(typeof(first(bodies).m), 3 * n)
     for i = 1:n
         indO, indH1, indH2 = 3 * (i - 1) + 1, 3 * (i - 1) + 2, 3 * (i - 1) + 3
         ms[indO] = system.mO
         ms[indH1] = system.mH
         ms[indH2] = system.mH
         push!(bonds, (indH1, indO, indH2, p.aHOH, p.ka))
-    end 
+    end
     return (ms, bonds)
 end
 
@@ -293,8 +293,8 @@ end
 
 function DiffEqBase.ODEProblem(simulation::NBodySimulation{<:PotentialNBodySystem})
     (u0, v0, n) = gather_bodies_initial_coordinates(simulation)
-    
-    acceleration_functions = gather_accelerations_for_potentials(simulation)   
+
+    acceleration_functions = gather_accelerations_for_potentials(simulation)
 
     function ode_system!(du, u, p, t)
         du[:, 1:n] = @view u[:, n + 1:2n];
@@ -302,32 +302,32 @@ function DiffEqBase.ODEProblem(simulation::NBodySimulation{<:PotentialNBodySyste
         @inbounds for i = 1:n
             a = MVector(0.0, 0.0, 0.0)
             for acceleration! in acceleration_functions
-                acceleration!(a, u[:, 1:n], u[:, n + 1:end], t, i);                
+                acceleration!(a, u[:, 1:n], u[:, n + 1:end], t, i);
             end
             du[:, n + i] .= a
-        end 
+        end
     end
 
     return ODEProblem(ode_system!, hcat(u0, v0), simulation.tspan)
 end
 
 function DiffEqBase.SecondOrderODEProblem(simulation::NBodySimulation{<:PotentialNBodySystem})
-    
+
     (u0, v0, n) = gather_bodies_initial_coordinates(simulation)
 
-    acceleration_functions = gather_accelerations_for_potentials(simulation)  
+    acceleration_functions = gather_accelerations_for_potentials(simulation)
     simultaneous_acceleration = gather_simultaneous_acceleration(simulation)
 
     function soode_system!(dv, v, u, p, t)
         @inbounds for i = 1:n
             a = MVector(0.0, 0.0, 0.0)
             for acceleration! in acceleration_functions
-                acceleration!(a, u, v, t, i);    
+                acceleration!(a, u, v, t, i);
             end
             dv[:, i] .= a
-        end 
+        end
         for acceleration! in simultaneous_acceleration
-            acceleration!(dv, u, v, t);    
+            acceleration!(dv, u, v, t);
         end
     end
 
@@ -335,35 +335,35 @@ function DiffEqBase.SecondOrderODEProblem(simulation::NBodySimulation{<:Potentia
 end
 
 function DiffEqBase.SecondOrderODEProblem(simulation::NBodySimulation{<:WaterSPCFw})
-    
+
     (u0, v0, n) = gather_bodies_initial_coordinates(simulation)
 
     (o_acelerations, h_acelerations) = gather_accelerations_for_potentials(simulation)
-    group_accelerations = gather_group_accelerations(simulation)   
+    group_accelerations = gather_group_accelerations(simulation)
     simultaneous_acceleration = gather_simultaneous_acceleration(simulation)
 
     function soode_system!(dv, v, u, p, t)
         @inbounds for i = 1:n
             a = MVector(0.0, 0.0, 0.0)
             for acceleration! in o_acelerations
-                acceleration!(a, u, v, t, 3 * (i - 1) + 1);    
+                acceleration!(a, u, v, t, 3 * (i - 1) + 1);
             end
             dv[:, 3 * (i - 1) + 1]  .= a
         end
         @inbounds for i in 1:n, j in (2, 3)
             a = MVector(0.0, 0.0, 0.0)
             for acceleration! in h_acelerations
-                acceleration!(a, u, v, t, 3 * (i - 1) + j);    
+                acceleration!(a, u, v, t, 3 * (i - 1) + j);
             end
             dv[:, 3 * (i - 1) + j]   .= a
-        end 
+        end
         @inbounds for i = 1:n
             for acceleration! in group_accelerations
-                acceleration!(dv, u, v, t, i);    
+                acceleration!(dv, u, v, t, i);
             end
         end
         for acceleration! in simultaneous_acceleration
-            acceleration!(dv, u, v, t);    
+            acceleration!(dv, u, v, t);
         end
     end
 
@@ -373,7 +373,7 @@ end
 function gather_accelerations_for_potentials(simulation::NBodySimulation{<:WaterSPCFw})
     o_acelerations = []
     h_acelerations = []
-    
+
     push!(o_acelerations, get_accelerating_function(simulation.system.e_parameters, simulation))
     push!(o_acelerations, get_accelerating_function(simulation.system.scpfw_parameters, simulation))
     push!(o_acelerations, get_accelerating_function(simulation.system.lj_parameters, simulation))
@@ -386,8 +386,8 @@ end
 
 function DiffEqBase.SDEProblem(simulation::NBodySimulation{<:PotentialNBodySystem})
     (u0, v0, n) = gather_bodies_initial_coordinates(simulation)
-    
-    acceleration_functions = gather_accelerations_for_potentials(simulation)   
+
+    acceleration_functions = gather_accelerations_for_potentials(simulation)
 
     therm = simulation.thermostat
 
@@ -397,7 +397,7 @@ function DiffEqBase.SDEProblem(simulation::NBodySimulation{<:PotentialNBodySyste
         @inbounds for i = 1:n
             a = MVector(0.0, 0.0, 0.0)
             for acceleration! in acceleration_functions
-                acceleration!(a, (@view u[:, 1:n]), (@view u[:, n + 1:end]), t, i);                
+                acceleration!(a, (@view u[:, 1:n]), (@view u[:, n + 1:end]), t, i);
             end
             du[:, n + i] .= a
         end
@@ -408,15 +408,15 @@ function DiffEqBase.SDEProblem(simulation::NBodySimulation{<:PotentialNBodySyste
     function noise!(du, u, p, t)
         @. du[:, n + 1:end] += σ
     end
-    
+
     return SDEProblem(deterministic_acceleration!, noise!, hcat(u0, v0), simulation.tspan)
 end
 
 function DiffEqBase.SDEProblem(simulation::NBodySimulation{<:WaterSPCFw})
     (u0, v0, n) = gather_bodies_initial_coordinates(simulation)
-       
+
     (o_acelerations, h_acelerations) = gather_accelerations_for_potentials(simulation)
-    group_accelerations = gather_group_accelerations(simulation)   
+    group_accelerations = gather_group_accelerations(simulation)
     simultaneous_acceleration = gather_simultaneous_acceleration(simulation)
 
     therm = simulation.thermostat
@@ -429,7 +429,7 @@ function DiffEqBase.SDEProblem(simulation::NBodySimulation{<:WaterSPCFw})
         @inbounds for i = 1:n
             a = MVector(0.0, 0.0, 0.0)
             for acceleration! in o_acelerations
-                acceleration!(a, (@view u[:, 1:3*n]), (@view u[:, 3*n+1 : 2*3*n]), t, 3 * (i - 1) + 1);    
+                acceleration!(a, (@view u[:, 1:3*n]), (@view u[:, 3*n+1 : 2*3*n]), t, 3 * (i - 1) + 1);
             end
             du[:, 3*n+3 * (i - 1) + 1]  .= a
 
@@ -440,24 +440,24 @@ function DiffEqBase.SDEProblem(simulation::NBodySimulation{<:WaterSPCFw})
         @inbounds for i in 1:n, j in (2, 3)
             a = MVector(0.0, 0.0, 0.0)
             for acceleration! in h_acelerations
-                acceleration!(a, (@view u[:, 1:3*n]), (@view u[:, 3*n+1 : 2*3*n]), t, 3 * (i - 1) + j);    
+                acceleration!(a, (@view u[:, 1:3*n]), (@view u[:, 3*n+1 : 2*3*n]), t, 3 * (i - 1) + j);
             end
             du[:, 3*n+3 * (i - 1) + j]   .= a
-        end 
+        end
         @inbounds for i = 1:n
             for acceleration! in group_accelerations
-                acceleration!((@view du[ :, 3*n+1 : 2*3*n]), (@view u[:, 1:3*n]), (@view u[:, 3*n+1 : 2*3*n]), t, i);    
+                acceleration!((@view du[ :, 3*n+1 : 2*3*n]), (@view u[:, 1:3*n]), (@view u[:, 3*n+1 : 2*3*n]), t, i);
             end
         end
         for acceleration! in simultaneous_acceleration
-            acceleration!((@view du[:, 3*n+1 : 2*3*n]), (@view u[:, 1:3*n]), (@view u[:, 3*n+1 : 2*3*n]), t);    
+            acceleration!((@view du[:, 3*n+1 : 2*3*n]), (@view u[:, 1:3*n]), (@view u[:, 3*n+1 : 2*3*n]), t);
         end
         @. du[:, 3*n+1 : 2*3*n] -= therm.γ*u[:, 3*n+1 : 2*3*n]
     end
-    
+
     σO = sqrt(2*therm.γ*simulation.kb*therm.T)/mO
     σH = sqrt(2*therm.γ*simulation.kb*therm.T)/mH
-    
+
     function noise!(du, u, p, t)
         @inbounds for i = 1:n
             @. du[:, 3*n+3 * (i - 1) + 1] += σO
@@ -465,6 +465,6 @@ function DiffEqBase.SDEProblem(simulation::NBodySimulation{<:WaterSPCFw})
             @. du[:, 3*n+3 * (i - 1) + 3] += σH
         end
     end
-    
+
     return SDEProblem(deterministic_acceleration!, noise!, hcat(u0, v0), simulation.tspan)
 end


### PR DESCRIPTION
I fixed some of the more obvious performance issues and rewrote the BC implementations, resulting in a ~30x speed improvement and about a 100x decrease in GC memory allocations. After the changes, I can now do about 5.5 ns/day (216 SPC/fw molecules, 1 fs timestep, velocity verlet) with no parallelization - a figure only about 3-4x away from OpenMM running in similar conditions. The tests pass, but I might have missed something along the way.

