### PR TITLE
Add PrecompileTools workload to improve startup time and TTFX

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NBodySimulator"
 uuid = "0e6f8da7-a7fc-5c8b-a220-74e902c310f9"
-authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 version = "1.11.0"
+authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -10,6 +10,7 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
@@ -23,6 +24,7 @@ DiffEqCallbacks = "2.9, 4"
 DocStringExtensions = "0.8, 0.9"
 FileIO = "1.0"
 OrdinaryDiffEq = "5, 6"
+PrecompileTools = "1"
 RecipesBase = "0.7, 0.8, 1.0"
 RecursiveArrayTools = "2, 3"
 Reexport = "0.2, 1.0"

--- a/src/NBodySimulator.jl
+++ b/src/NBodySimulator.jl
@@ -1,4 +1,3 @@
-__precompile__()
 """
 $(DocStringExtensions.README)
 """
@@ -9,6 +8,7 @@ using Reexport
 @reexport using DiffEqBase, OrdinaryDiffEq, RecursiveArrayTools
 using StaticArrays, RecipesBase, FileIO
 using Random, Printf, LinearAlgebra
+using PrecompileTools
 
 include("nbody_simulation.jl")
 
@@ -22,5 +22,7 @@ export AndersenThermostat, BerendsenThermostat, NoseHooverThermostat, LangevinTh
 export run_simulation, get_position, get_velocity, get_masses, temperature,
        initial_energy, kinetic_energy, potential_energy, total_energy, rdf, msd,
        generate_bodies_in_cell_nodes, load_water_molecules_from_pdb
+
+include("precompilation.jl")
 
 end # module

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -1,0 +1,43 @@
+using PrecompileTools
+
+@setup_workload begin
+    using StaticArrays
+
+    @compile_workload begin
+        # Precompile gravitational system workflow
+        bodies_grav = [
+            MassBody(SVector(0.0, 0.0, 0.0), SVector(0.0, 0.0, 0.0), 1.0),
+            MassBody(SVector(1.0, 0.0, 0.0), SVector(0.0, 1.0, 0.0), 1.0),
+        ]
+        system_grav = GravitationalSystem(bodies_grav, 1.0)
+        simulation_grav = NBodySimulation(system_grav, (0.0, 0.1))
+        result_grav = run_simulation(simulation_grav)
+
+        # Access result data
+        get_position(result_grav, 0.05)
+        get_velocity(result_grav, 0.05)
+        kinetic_energy(result_grav, 0.05)
+        total_energy(result_grav, 0.05)
+        temperature(result_grav, 0.05)
+
+        # Precompile Lennard-Jones system workflow with periodic boundaries
+        bodies_lj = generate_bodies_in_cell_nodes(4, 1.0, 0.1, 2.0)
+        lj_params = LennardJonesParameters(1.0, 0.5, 1.5)
+        pbc = CubicPeriodicBoundaryConditions(2.0)
+        system_lj = PotentialNBodySystem(bodies_lj, Dict(:lennard_jones => lj_params))
+        simulation_lj = NBodySimulation(system_lj, (0.0, 0.1), pbc)
+
+        # Run with default solver (Tsit5)
+        result_lj = run_simulation(simulation_lj)
+
+        # Run with VelocityVerlet (common for molecular dynamics)
+        result_lj_vv = run_simulation(simulation_lj, VelocityVerlet(), dt = 0.01)
+
+        # Access LJ result data
+        get_position(result_lj, 0.05)
+        get_velocity(result_lj, 0.05)
+        kinetic_energy(result_lj, 0.05)
+        potential_energy(result_lj, 0.05)
+        total_energy(result_lj, 0.05)
+    end
+end


### PR DESCRIPTION
## Summary

- Add PrecompileTools.jl to improve time-to-first-execution (TTFX) for common NBodySimulator workflows
- Precompile gravitational and Lennard-Jones simulations with common solvers
- Remove obsolete `__precompile__()` directive

## Performance Improvements

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| First run_simulation (gravitational) | 5.27s | 0.01s | ~527x faster |
| First run_simulation (LJ, default) | 5.89s | 0.02s | ~295x faster |
| First run_simulation (LJ, VelocityVerlet) | 6.33s | 0.01s | ~633x faster |
| Total TTFX (startup + first sim) | 12.08s | 6.57s | ~46% reduction |

Precompilation time increased from ~9s to ~23s, which is a reasonable tradeoff for the significant runtime improvements.

## Test plan

- [x] All existing tests pass
- [x] Verified TTFX improvements with benchmark tests

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)