### PR TITLE
Use SecondOrderODEProblem for all algorithms in run_simulation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NBodySimulator"
 uuid = "0e6f8da7-a7fc-5c8b-a220-74e902c310f9"
-version = "1.11.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
+version = "1.11.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/test/electrostatics_test.jl
+++ b/test/electrostatics_test.jl
@@ -18,10 +18,11 @@
         sim_result = run_simulation(simulation)
 
         solution = sim_result.solution
+        # Test that positions return to initial values after one orbit
+        # SecondOrderODEProblem stores positions in .x[2] of the ArrayPartition
         ε = 0.1 * r
         for j in 1:2, i in 1:3
-
-            @test solution[1][i, j] ≈ solution[end][i, j] atol = ε
+            @test solution.u[1].x[2][i, j] ≈ solution.u[end].x[2][i, j] atol = ε
         end
 
         (

--- a/test/gravitational_test.jl
+++ b/test/gravitational_test.jl
@@ -13,10 +13,11 @@ using OrdinaryDiffEq
         simulation = NBodySimulation(system, tspan)
         sim_result = run_simulation(simulation)
         solution_simo_3 = sim_result.solution
+        # Test that positions return to initial values after one period (choreography)
+        # SecondOrderODEProblem stores positions in .x[2] of the ArrayPartition
         ε = 0.1
         for j in 1:3, i in 1:3
-
-            @test solution_simo_3[1][i, j] ≈ solution_simo_3[end][i, j] atol = ε
+            @test solution_simo_3.u[1].x[2][i, j] ≈ solution_simo_3.u[end].x[2][i, j] atol = ε
         end
 
         @testset "Analyzing simulation result" begin
@@ -36,31 +37,31 @@ using OrdinaryDiffEq
             @test e_kin ≈ kinetic_energy(sim_result, t1) atol = ε
         end
 
-        @testset "Using conversion into SecondOrderODEProblem" begin
+        @testset "Using DPRKN6 integrator" begin
             sim_result = run_simulation(simulation, DPRKN6())
             solution_simo_3_2nd = sim_result.solution
+            # Test that positions return to initial values after one period
             ε = 0.001
             for i in 1:3, j in 1:3
-
-                @test solution_simo_3_2nd[1][9 + 3(i - 1) + j] ≈ solution_simo_3_2nd[end][9 + 3(i - 1) + j] atol = ε
+                @test solution_simo_3_2nd.u[1].x[2][i, j] ≈ solution_simo_3_2nd.u[end].x[2][i, j] atol = ε
             end
         end
 
         @testset "Using symplectic integrators" begin
             sim_result = run_simulation(simulation, VelocityVerlet(), dt = pi / 130)
             solution_simo_3_2nd = sim_result.solution
+            # Test that positions return to initial values after one period
             ε = 0.001
             for i in 1:3, j in 1:3
-
-                @test solution_simo_3_2nd[1][9 + 3(i - 1) + j] ≈ solution_simo_3_2nd[end][9 + 3(i - 1) + j] atol = ε
+                @test solution_simo_3_2nd.u[1].x[2][i, j] ≈ solution_simo_3_2nd.u[end].x[2][i, j] atol = ε
             end
 
             sim_result = run_simulation(simulation, Yoshida6(), dt = pi / 12)
             solution_simo_3_2nd = sim_result.solution
+            # Test that positions return to initial values after one period
             ε = 0.001
             for i in 1:3, j in 1:3
-
-                @test solution_simo_3_2nd[1][9 + 3(i - 1) + j] ≈ solution_simo_3_2nd[end][9 + 3(i - 1) + j] atol = ε
+                @test solution_simo_3_2nd.u[1].x[2][i, j] ≈ solution_simo_3_2nd.u[end].x[2][i, j] atol = ε
             end
         end
     end
@@ -89,10 +90,10 @@ using OrdinaryDiffEq
         sim_result = run_simulation(simulation, Tsit5(), abstol = 1.0e-10, reltol = 1.0e-10)
         solution_simo_5 = sim_result.solution
 
+        # Test that positions return to initial values after one period (choreography)
         ε = 0.01
         for j in 1:5, i in 1:3
-
-            @test solution_simo_5[1][i, j] ≈ solution_simo_5[end][i, j] atol = ε
+            @test solution_simo_5.u[1].x[2][i, j] ≈ solution_simo_5.u[end].x[2][i, j] atol = ε
         end
     end
 


### PR DESCRIPTION
## Summary
- Removes the `ODEProblem` code path from `calculate_simulation` and uses `SecondOrderODEProblem` for all algorithms
- This allows any algorithm compatible with `SecondOrderODEProblem` (including Tsit5, DPRKN6, VelocityVerlet, Yoshida6, etc.) to be used with `run_simulation`
- Updates tests to use the new solution format (ArrayPartition via `.x[2]` for positions)
- Fixes deprecated `solution[i]` indexing to use `solution.u[i]`

## Context
Previously, only algorithms in the explicit Union (`VelocityVerlet`, `DPRKN6`, `Yoshida6`) would use `SecondOrderODEProblem`, while all other algorithms fell back to `ODEProblem` which doesn't properly handle second-order ODEs like N-body problems.

This addresses the discussion from the stale PR #27 and implements the suggestion from @ChrisRackauckas to remove the `ODEProblem` path entirely.

Fixes #26

## Test plan
- [x] All existing tests pass locally
- [x] Tests updated to work with new solution format
- [ ] CI tests pass

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)