### PR TITLE
Use SciMLTesting v1.2 (folder-based run_tests)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,6 +37,8 @@ PrecompileTools = "1.2.0"
 RecipesBase = "1.3.4"
 RecursiveArrayTools = "3.36.0, 4"
 Reexport = "1.2.0"
+SafeTestsets = "0.1, 1"
+SciMLTesting = "1"
 StaticArrays = "1.9.18"
 StochasticDiffEq = "6.80.0, 7"
 Test = "1"
@@ -44,10 +46,11 @@ julia = "1.10"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Pkg", "StaticArrays", "StochasticDiffEq", "LinearAlgebra", "Test"]
+test = ["LinearAlgebra", "SafeTestsets", "SciMLTesting", "StaticArrays", "StochasticDiffEq", "Test"]

--- a/test/custom_potential_test.jl
+++ b/test/custom_potential_test.jl
@@ -1,50 +1,7 @@
-struct CustomPotentialParameters <: PotentialParameters
-    a::AbstractFloat
-end
-
-import NBodySimulator.get_accelerating_function
-function get_accelerating_function(
-        p::CustomPotentialParameters,
-        simulation::NBodySimulation
-    )
-    return (dv, u, v, t, i) -> begin
-        custom_accel = SVector(p.a, 0.0, 0.0)
-        dv .= custom_accel
-    end
-end
-
-@testset "A system with custom potential" begin
-    m1 = 1.0
-    m2 = 1.0
-
-    t1 = 0.0
-    t2 = 1.0
-    τ = (t2 - t1) / 100
-
-    p1 = MassBody(SVector(1, 0.0, 0.0), SVector(0.0, 0.0, 0.0), m1)
-    p2 = MassBody(SVector(-1, 0.0, 0.0), SVector(0.0, 0.0, 0.0), m2)
-
-    parameters = CustomPotentialParameters(1.5)
-    system = PotentialNBodySystem([p1, p2], Dict(:custom_potential_params => parameters))
-    simulation = NBodySimulation(system, (t1, t2))
-    simResult = run_simulation(simulation, VelocityVerlet(), dt = τ)
-
-    v2 = get_velocity(simResult, t2, 1)
-    r2 = get_position(simResult, t2, 1)
-
-    ε = 1.0e-6
-    @test 1.5 ≈ v2[1] atol = ε
-    @test 1.75 ≈ r2[1] atol = ε
-
-    potential_system = PotentialNBodySystem(
-        [p1, p2];
-        potentials = [
-            :lennard_jones,
-            :electrostatic,
-            :gravitational,
-            :magnetostatic,
-        ]
-    )
-    @test sprint(io -> show(io, potential_system)) ==
-        "Potentials: \nLennard-Jones:\n\tϵ:1.0\n\tσ:1.0\n\tR:2.5\nElectrostatic:\n\tk:9.0e9\nMagnetostatic:\n\tμ/4π:1.0e-7\nGravitational:\n\tG:6.67408e-11\n"
+@safetestset "A system with custom potential" begin
+    # Body lives in an included file so that the `import NBodySimulator.get_accelerating_function`
+    # + method extension are evaluated as module-top-level statements. Inside an inline
+    # @safetestset body they land in the testset's local scope, where `import` fails with
+    # "expected Symbol, got a value of type Core.SlotNumber".
+    include(joinpath(@__DIR__, "shared", "custom_potential_body.jl"))
 end

--- a/test/electrostatics_test.jl
+++ b/test/electrostatics_test.jl
@@ -1,4 +1,6 @@
-@testset "Electrostatics Functional Tests" begin
+@safetestset "Electrostatics Functional Tests" begin
+    using NBodySimulator, StaticArrays, LinearAlgebra
+
     k = 9.0e9
 
     @testset "One particle rotates around another" begin

--- a/test/gravitational_test.jl
+++ b/test/gravitational_test.jl
@@ -1,6 +1,6 @@
-using OrdinaryDiffEq
+@safetestset "Gravitational Functional Test" begin
+    using NBodySimulator, StaticArrays, OrdinaryDiffEq
 
-@testset "Gravitational Functional Test" begin
     G = 1
     @testset "The well-known figure Eight choreography" begin
         m1 = MassBody(SVector(-0.995492, 0.0, 0.0), SVector(-0.347902, -0.53393, 0.0), 1.0)

--- a/test/interface_test.jl
+++ b/test/interface_test.jl
@@ -1,6 +1,6 @@
-using Test, NBodySimulator, StaticArrays, OrdinaryDiffEq
+@safetestset "Interface Compatibility" begin
+    using NBodySimulator, StaticArrays, OrdinaryDiffEq
 
-@testset "Interface Compatibility" begin
     @testset "BigFloat support" begin
         # Create bodies with BigFloat coordinates
         body1 = MassBody(

--- a/test/lennard_jones_test.jl
+++ b/test/lennard_jones_test.jl
@@ -1,4 +1,5 @@
-@testset "Lennard-Jones potential" begin
+@safetestset "Lennard-Jones potential" begin
+    using NBodySimulator, StaticArrays, LinearAlgebra
     @testset "Two interacting particles" begin
         m1 = 1.0
         m2 = 1.0

--- a/test/magnetostaic_test.jl
+++ b/test/magnetostaic_test.jl
@@ -1,4 +1,6 @@
-@testset "Magnetostatics Functional Tests" begin
+@safetestset "Magnetostatics Functional Tests" begin
+    using NBodySimulator, StaticArrays, LinearAlgebra
+
     @testset "Repelling magnetic dipoles" begin
         d1 = 0.01 # m
         m1 = 5.0e-6 # kg

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,7 +2,8 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 NBodySimulator = "0e6f8da7-a7fc-5c8b-a220-74e902c310f9"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -11,5 +12,7 @@ NBodySimulator = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
+SciMLTesting = "1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,7 +1,3 @@
-using Pkg
-Pkg.activate(@__DIR__)
-Pkg.instantiate()
-
 using NBodySimulator, Aqua, JET, Test
 
 @testset "Aqua" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,20 +1,2 @@
-using Test
-
-const GROUP = get(ENV, "GROUP", "All")
-
-if GROUP == "All" || GROUP == "Core"
-    using NBodySimulator, StaticArrays, LinearAlgebra, StochasticDiffEq
-
-    include("lennard_jones_test.jl")
-    include("electrostatics_test.jl")
-    include("gravitational_test.jl")
-    include("custom_potential_test.jl")
-    include("magnetostaic_test.jl")
-    include("thermostat_test.jl")
-    include("water_test.jl")
-    include("interface_test.jl")
-end
-
-if GROUP == "QA"
-    include("qa/qa.jl")
-end
+using SciMLTesting
+run_tests()

--- a/test/shared/custom_potential_body.jl
+++ b/test/shared/custom_potential_body.jl
@@ -1,0 +1,50 @@
+using NBodySimulator, StaticArrays, Test
+
+struct CustomPotentialParameters <: PotentialParameters
+    a::AbstractFloat
+end
+
+import NBodySimulator.get_accelerating_function
+function get_accelerating_function(
+        p::CustomPotentialParameters,
+        simulation::NBodySimulation
+    )
+    return (dv, u, v, t, i) -> begin
+        custom_accel = SVector(p.a, 0.0, 0.0)
+        dv .= custom_accel
+    end
+end
+
+m1 = 1.0
+m2 = 1.0
+
+t1 = 0.0
+t2 = 1.0
+τ = (t2 - t1) / 100
+
+p1 = MassBody(SVector(1, 0.0, 0.0), SVector(0.0, 0.0, 0.0), m1)
+p2 = MassBody(SVector(-1, 0.0, 0.0), SVector(0.0, 0.0, 0.0), m2)
+
+parameters = CustomPotentialParameters(1.5)
+system = PotentialNBodySystem([p1, p2], Dict(:custom_potential_params => parameters))
+simulation = NBodySimulation(system, (t1, t2))
+simResult = run_simulation(simulation, VelocityVerlet(), dt = τ)
+
+v2 = get_velocity(simResult, t2, 1)
+r2 = get_position(simResult, t2, 1)
+
+ε = 1.0e-6
+@test 1.5 ≈ v2[1] atol = ε
+@test 1.75 ≈ r2[1] atol = ε
+
+potential_system = PotentialNBodySystem(
+    [p1, p2];
+    potentials = [
+        :lennard_jones,
+        :electrostatic,
+        :gravitational,
+        :magnetostatic,
+    ]
+)
+@test sprint(io -> show(io, potential_system)) ==
+    "Potentials: \nLennard-Jones:\n\tϵ:1.0\n\tσ:1.0\n\tR:2.5\nElectrostatic:\n\tk:9.0e9\nMagnetostatic:\n\tμ/4π:1.0e-7\nGravitational:\n\tG:6.67408e-11\n"

--- a/test/thermostat_test.jl
+++ b/test/thermostat_test.jl
@@ -1,4 +1,6 @@
-@testset "Testing thermostats on liquid argon " begin
+@safetestset "Testing thermostats on liquid argon " begin
+    using NBodySimulator, StochasticDiffEq
+
     T = 120.0 # °K
     T0 = 90 # °K
     kb = 8.3144598e-3 # kJ/(K*mol)

--- a/test/water_test.jl
+++ b/test/water_test.jl
@@ -1,4 +1,6 @@
-@testset "Water SPC/Fw test" begin
+@safetestset "Water SPC/Fw test" begin
+    using NBodySimulator, StaticArrays, LinearAlgebra, StochasticDiffEq
+
     qp = 1 # charge of a proton
     T = 298.16 # °K
     kb = 8.3144598e-3 # kJ/(K*mol)


### PR DESCRIPTION
Converts the test suite to the SciMLTesting v1.2 folder-discovery model: `test/runtests.jl` is now just `using SciMLTesting; run_tests()`.

- **Core** = the top-level `test/*.jl` files, each run in its own `@safetestset` (isolated module) by the harness. Each file carries its own `using NBodySimulator, ...`. The `show`/`string` assertions on NBodySimulator types (e.g. `InfiniteBox{Float64}([...])`) still print unqualified because the active module stays `Main` inside a `@safetestset`, so qualification is unchanged.
- `custom_potential_test.jl`'s body — which extends `NBodySimulator.get_accelerating_function` through a module-top-level `import` — lives in `test/shared/custom_potential_body.jl` and is `include`d explicitly. `test/shared/` is **not** a declared group, so it is not auto-discovered as a Core file (no double execution).
- **QA** = `test/qa/` (its `Project.toml` sub-env is activated automatically). The `qa.jl` Aqua/JET `@test_broken` markers tracking #117 are unchanged; the redundant `Pkg.activate`/`instantiate` preamble was removed (the harness owns it).
- Deps: add `SciMLTesting` + `SafeTestsets` to the root `[extras]`/test target/`[compat]` and to `test/qa/Project.toml`; drop `Pkg` (the v1.2 harness owns all `Pkg` ops).
- `test/test_groups.toml` is unchanged. Per-file `@test`/`@test_broken` counts are preserved exactly against `master`, so the set of tests run under each `GROUP` value is unchanged.

Verified locally on Julia 1.11: folder discovery resolves Core to the 8 top-level test files (excluding the `shared/` helper) and QA to `test/qa/qa.jl` with sub-env activation.

This PR (originally the `canonicalize-safetestset` work) is now the single consolidated v1.2 folder conversion.

Ignore until reviewed by @ChrisRackauckas.
