### PR TITLE
Add explicit show methods for boundary condition types (fix Core/Downgrade CI)

### DIFF
--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -6,6 +6,16 @@ end
 
 PeriodicBoundaryConditions(L::Real) = PeriodicBoundaryConditions(SVector(0, L, 0, L, 0, L))
 
+# Explicit `show` so the printed representation is independent of the module the
+# IO context resolves to (the default struct printer qualifies the type name with
+# `NBodySimulator.` when the binding is not visible from the printing module, e.g.
+# inside an isolated `@safetestset` module).
+function Base.show(io::IO, bc::PeriodicBoundaryConditions{cType}) where {cType}
+    print(io, "PeriodicBoundaryConditions{", cType, "}(")
+    show(io, bc.boundary)
+    return print(io, ")")
+end
+
 function Base.iterate(pbc::PeriodicBoundaryConditions, state = 1)
     state > length(pbc.boundary) && return nothing
     return pbc.boundary[state], state + 1
@@ -22,8 +32,20 @@ end
 
 InfiniteBox() = InfiniteBox(SVector(-Inf, Inf, -Inf, Inf, -Inf, Inf))
 
+function Base.show(io::IO, bc::InfiniteBox{cType}) where {cType}
+    print(io, "InfiniteBox{", cType, "}(")
+    show(io, bc.boundary)
+    return print(io, ")")
+end
+
 struct CubicPeriodicBoundaryConditions{cType <: Real} <: BoundaryConditions
     L::cType
+end
+
+function Base.show(io::IO, bc::CubicPeriodicBoundaryConditions{cType}) where {cType}
+    print(io, "CubicPeriodicBoundaryConditions{", cType, "}(")
+    show(io, bc.L)
+    return print(io, ")")
 end
 
 function get_interparticle_distance(ri, rj, pbc::PeriodicBoundaryConditions)


### PR DESCRIPTION
## Problem

Master CI is red on the `Core` test group (Julia lts/1/pre) and on `Downgrade`. All four jobs fail on the same two assertions in `test/lennard_jones_test.jl` (lines 39 & 42):

```
Evaluated: "...Boundary conditions: NBodySimulator.InfiniteBox{Float64}([-Inf, ...])..."
Expected:  "...Boundary conditions: InfiniteBox{Float64}([-Inf, ...])..."
```

## Root cause

`InfiniteBox` (like the other boundary-condition types) has no custom `Base.show`, so it uses the default struct printer. That printer qualifies the type name with its defining module (`NBodySimulator.`) whenever the binding is not visible from the module the printing IO context resolves to. Under `SafeTestsets`, each test file runs inside its own isolated module, so `using NBodySimulator` brings the names into that module but **not** into `Main` — and the default printer resolves the context to `Main`, where `InfiniteBox` is not in scope. The result is the module-qualified `NBodySimulator.InfiniteBox{...}`, which breaks the exact-string assertions.

This is brittleness in the package's display behavior, not a functional regression: the boundary-condition code works fine.

## Fix

Add explicit `Base.show` methods for `PeriodicBoundaryConditions`, `InfiniteBox`, and `CubicPeriodicBoundaryConditions` so the printed representation is deterministic and independent of the printing module. The output matches the package's intended unqualified form (`InfiniteBox{Float64}([...])`).

No tests were skipped, weakened, or had tolerances loosened.

## Local verification (Julia 1.10.11)

`Pkg.test` with `GROUP=Core` (the exact CI path, SafeTestsets isolation included):

```
Core/lennard_jones_test.jl |   25     25  12.6s
...
     Testing NBodySimulator tests passed
```

(`lennard_jones_test.jl` previously reported `23 pass / 2 fail`; now `25/25`.) Runic `--check` on the edited file passes.

## Scope

This fixes the `Core` (x3) and `Downgrade` failures, which share this single root cause. The separate `Documentation` job failure (a `linkcheck` 404 on a StaticArrays docs URL plus a curl failure on an external MPI PDF) is unrelated and not addressed here.

Please ignore until reviewed by @ChrisRackauckas.
