### PR TITLE
Fix dead linkcheck links in docs (StaticArrays quickstart, Berendsen thermostat)

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,7 +28,7 @@ mass = 1.25
 body = MassBody(r, v, mass)
 ```
 
-For simulation speed, it is advised to use [static arrays](https://juliaarrays.github.io/StaticArrays.jl/stable/pages/quickstart/).
+For simulation speed, it is advised to use [static arrays](https://juliaarrays.github.io/StaticArrays.jl/stable/quickstart/).
 
 A **System** covers the bodies and the necessary parameters for the correct simulation of interaction between particles. For example, to create an entity for a system of gravitationally interacting particles, one needs to use `GravitationalSystem` constructor:
 
@@ -311,7 +311,7 @@ thermostat = AndersenThermostat(90, ν)
 
 ![andersen thermostating](https://user-images.githubusercontent.com/16945627/44002487-cd99653a-9e5c-11e8-8481-78945a930d94.png)
 
-### [Berendsen Thermostat](https://www2.mpip-mainz.mpg.de/%7Eandrienk/journal_club/thermostats.pdf)
+### [Berendsen Thermostat](http://www.sklogwiki.org/SklogWiki/index.php/Berendsen_thermostat)
 
 ```julia
 τB = 2000τ


### PR DESCRIPTION
## Problem

The `Documentation / Build and Deploy Documentation` check is the only red on master. It fails because Documenter is configured with `linkcheck = true` and two external links in `docs/src/index.md` are dead:

- `https://juliaarrays.github.io/StaticArrays.jl/stable/pages/quickstart/` -> **404** (StaticArrays docs dropped the `pages/` path segment; it is now `/stable/quickstart/`).
- `https://www2.mpip-mainz.mpg.de/%7Eandrienk/journal_club/thermostats.pdf` -> host no longer resolves (curl exit 6), used as the "Berendsen Thermostat" section reference.

## Fix

- Update the StaticArrays quickstart link to the current URL `/stable/quickstart/`.
- Replace the dead Berendsen PDF reference with the SklogWiki Berendsen thermostat page, matching the existing Andersen and Nose-Hoover thermostat section headers (which already link to SklogWiki).

## Verification

Reproduced the failure locally on Julia 1.12 (the "1" CI channel) and verified the two links with the exact `curl` invocation Documenter's linkcheck uses:

- Old StaticArrays URL: `404`; old thermostats PDF: curl exit 6 (unresolvable host).
- New StaticArrays URL: `200`; new SklogWiki Berendsen URL: `200`.

After the change, neither previously-failing link appears in the local linkcheck output. (Local full builds intermittently hit transient `429` rate-limits on healthy github.com links from a single source IP; those are not present in GitHub Actions runs and were not failing in the original CI.)

Please ignore until reviewed by @ChrisRackauckas