### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,7 +2,6 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 NBodySimulator = "0e6f8da7-a7fc-5c8b-a220-74e902c310f9"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -11,8 +10,7 @@ NBodySimulator = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
-JET = "0.9,0.10,0.11"
-SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+JET = "0.9, 0.10, 0.11"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,12 +1,25 @@
-using NBodySimulator, Aqua, JET, Test
+using SciMLTesting, NBodySimulator, JET, Test
 
-@testset "Aqua" begin
-    Aqua.test_all(NBodySimulator; stale_deps = false, deps_compat = false)
-    @test_broken false  # Aqua stale_deps: JLArrays declared but unused — see https://github.com/SciML/NBodySimulator.jl/issues/117
-    @test_broken false  # Aqua deps_compat (deps): Printf, Random lack compat — see https://github.com/SciML/NBodySimulator.jl/issues/117
-    @test_broken false  # Aqua deps_compat (extras): Pkg lacks compat — see https://github.com/SciML/NBodySimulator.jl/issues/117
-end
-
-@testset "JET" begin
-    @test_broken false  # JET: PotentialNBodySystem default potentials=[] is Vector{Any}, not Vector{Symbol} (src/nbody_system.jl:35) — see https://github.com/SciML/NBodySimulator.jl/issues/117
-end
+run_qa(
+    NBodySimulator;
+    explicit_imports = true,
+    # Aqua sub-checks tracked-broken in https://github.com/SciML/NBodySimulator.jl/issues/117:
+    #   stale_deps:   JLArrays declared in [deps] but unused in src/
+    #   deps_compat:  Printf, Random (used in src/) lack [compat] bounds
+    aqua_broken = (:stale_deps, :deps_compat),
+    # `@def`, `AbstractTimeseriesSolution`, `DECallback` are SciMLBase names accessed
+    # via DiffEqBase (which re-exports them); ExplicitImports attributes them to their
+    # SciMLBase owner. They go public/owner-clean as those base libs release.
+    ei_kwargs = (;
+        all_qualified_accesses_via_owners = (;
+            ignore = (Symbol("@def"), :AbstractTimeseriesSolution, :DECallback),
+        ),
+        all_qualified_accesses_are_public = (;
+            ignore = (Symbol("@def"), :AbstractTimeseriesSolution, :DECallback),
+        ),
+    ),
+    # 39 implicit imports via heavy `@reexport using DiffEqBase, OrdinaryDiffEq, ...`;
+    # a mass `using X: a, b` refactor is risky alongside @reexport — tracked in
+    # https://github.com/SciML/NBodySimulator.jl/issues/121
+    ei_broken = (:no_implicit_imports,),
+)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Brings this repo's QA group onto the SciMLTesting **v1.6 `run_qa`** form with **ExplicitImports enabled** (folder model `test/qa/qa.jl`).

`test/qa/qa.jl` becomes:

```julia
using SciMLTesting, NBodySimulator, JET, Test

run_qa(
    NBodySimulator;
    explicit_imports = true,
    aqua_broken = (:stale_deps, :deps_compat),
    ei_kwargs = (;
        all_qualified_accesses_via_owners = (; ignore = (Symbol("@def"), :AbstractTimeseriesSolution, :DECallback)),
        all_qualified_accesses_are_public = (; ignore = (Symbol("@def"), :AbstractTimeseriesSolution, :DECallback)),
    ),
    ei_broken = (:no_implicit_imports,),
)
```

### ExplicitImports (6 checks)
| Check | Result | Handling |
|---|---|---|
| `no_stale_explicit_imports` | PASS | — |
| `all_explicit_imports_via_owners` | PASS | — |
| `all_explicit_imports_are_public` | PASS | — |
| `all_qualified_accesses_via_owners` | was FAIL | ignore `@def`, `AbstractTimeseriesSolution`, `DECallback` |
| `all_qualified_accesses_are_public` | was FAIL | ignore (same 3) |
| `no_implicit_imports` | FAIL (39 names) | `ei_broken` + tracking issue #121 |

The 3 ignored qualified-access names are **SciMLBase** names accessed via **DiffEqBase** (which re-exports them); ExplicitImports attributes them to their SciMLBase owner. They go owner-/public-clean as those base libs release.

`no_implicit_imports` finds 39 implicit names from the heavy `@reexport using DiffEqBase, OrdinaryDiffEq, OrdinaryDiffEqRKN, OrdinaryDiffEqSymplecticRK, RecursiveArrayTools` + `using StaticArrays, RecipesBase, FileIO, Random, Printf, LinearAlgebra, PrecompileTools`. A mass `using X: a, b` refactor is risky alongside `@reexport` (which deliberately re-exports the DiffEq solver surface to NBodySimulator's users), so it is `ei_broken = (:no_implicit_imports,)` and tracked in #121.

### Preserved / dropped broken markers
- **Aqua `:stale_deps`** (JLArrays declared in `[deps]` but unused in `src/`) and **`:deps_compat`** (Printf, Random used in `src/` lack `[compat]` bounds) — preserved as `aqua_broken`, tracked in #117. `run_qa` disables those sub-checks in `Aqua.test_all` and emits tracked `@test_broken` placeholders.
- **JET** `@test_broken false` placeholder — **dropped**: real `JET.test_package(NBodySimulator; target_modules = (NBodySimulator,), mode = :typo)` now PASSES (verified), so JET runs hard and green.
- **Aqua `deps_compat` (extras: Pkg)** placeholder — **dropped**: `Pkg` is no longer in the test extras under the folder model (subsumed by the `:deps_compat` umbrella regardless).

### Deps (`test/qa/Project.toml`)
- `SciMLTesting` compat `"1"` → `"1.6"`.
- Dropped `SafeTestsets` (transitive via SciMLTesting; `@safetestset` in the folder harness comes from SciMLTesting's own dep — verified by the full-harness run below).
- Kept `Aqua` as a direct dep: `Aqua.test_ambiguities` spawns a child process that `using Aqua`, which needs Aqua resolvable in the active env (without it, the ambiguity check errors with `Package Aqua not found in current path`).
- Kept `JET` (it runs). `ExplicitImports` stays out (transitive via SciMLTesting).

### Verification (against released SciMLTesting 1.6.0; Pkg resolves it, no dev-from-branch)
QA group **12 Pass / 3 Broken / 0 Fail / 0 Error** on:
- Julia 1.10 (lts), via direct `qa.jl` and full `Pkg.test` `GROUP=QA` folder-model harness (`QA/qa.jl` testset; "Testing NBodySimulator tests passed").
- Julia 1.12 (the "1" lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)