### PR TITLE
Release prep: bump to 1.14.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NBodySimulator"
 uuid = "0e6f8da7-a7fc-5c8b-a220-74e902c310f9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.13.1"
+version = "1.14.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
Version-bump-only release PR. Minor bump (not patch): exports get_accelerating_function and save_to_pdb, which were previously unexported/internal-only -- genuine new public API addition.