### PR TITLE
Drop DiffEqCallbacks 2 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 ArrayInterface = "7.22.0"
 DiffEqBase = "6.176.0, 7"
-DiffEqCallbacks = "2.35.0, 4"
+DiffEqCallbacks = "4"
 DocStringExtensions = "0.9.3"
 LinearAlgebra = "1"
 FileIO = "1.19.0"


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- remove the stale DiffEqCallbacks 2 compatibility line
- require DiffEqCallbacks 4, whose floor resolves to 4.0.0

This changes compatibility metadata only; no runtime code or public API changes.

## Rationale

DiffEqCallbacks 4 has been available since September 2024, while the retained 2.x line dates to the older callback API. The deployed downgrade resolver successfully resolves the remaining compatibility graph at DiffEqCallbacks 4.0.0.

## Validation

- Julia 1.10 locked downgrade environment, with an explicit `DiffEqCallbacks == v"4.0.0"` assertion: all Core files passed (184 assertions total)
- Julia 1.12 current-resolution `GROUP=Core`: all Core files passed (184 assertions total)
- Julia 1.12 current-resolution `GROUP=QA`: 14 passed, 3 pre-existing broken checks, suite passed
- `Pkg.precompile()` and `Pkg.build()` completed locally
- Runic checked the full repository with no changes required

The existing downgrade and functional suites directly exercise this metadata-only change, so no new source-level test was added.
