### PR TITLE
Make the strict-QA release non-breaking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NBodySimulator"
 uuid = "0e6f8da7-a7fc-5c8b-a220-74e902c310f9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.0"
+version = "1.15.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `NBodySimulator` | 2.0.0 | 1.15.0 | QA reexport removal is not a public API break |


## Why

The version was bumped to a breaking release because the strict SciMLTesting 2.4
QA migration dropped `@reexport`s and other foreign names from the namespace.
Those names were never this package's documented public API, so re-exporting them
is not behaviour downstream users were entitled to rely on, and removing them does
not warrant a major bump. Every name the package itself exports is unchanged.

This lowers the version to the next non-breaking release instead.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).