### PR TITLE
Release NBodySimulator 1.16.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NBodySimulator"
 uuid = "0e6f8da7-a7fc-5c8b-a220-74e902c310f9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.15.0"
+version = "1.16.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
## What changed and why

Bumps NBodySimulator from 1.15.0 to 1.16.0 to release the restored, explicitly documented solver surface from https://github.com/SciML/NBodySimulator.jl/pull/135, together with the already-merged compat corrections. This is the next consecutive version and follows the minor-bump policy for restored public API in a package at version 1 or later.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

- `~/.juliaup/bin/julia +release -m Runic --check .` — exited 0.
- `typos Project.toml` — exited 0 with no findings.
- `GROUP=QA ~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — `QA/qa.jl | 127 passed / 127 total`; package tests passed.
- `~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — eight Core testsets, 184 passed / 184 total; package tests passed.

## Not verified

The docs build and downstream/allowed-to-fail jobs were not run locally because this PR changes only the package version. The known docs deployment SSH failure is outside this version-only change.

AI continuation: OpenAI Codex session ID 01a03a11-47c2-77e0-858b-167004f0b79c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
